### PR TITLE
Add unset values functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Get a value in a specific path.
 #### Return
 - **Value** The object path value.
 
+### `unset(path)`
+Remove a path from a JSON object.
+
+#### Params
+
+- **String** `path`:
+
+#### Return
+- **JsonEditor** The `JsonEditor` instance.
+
 ### `read(cb)`
 Read the JSON file.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const findValue = require("find-value")
     , setValue = require("set-value")
+    , unsetValue = require("unset-value")
     , rJson = require("r-json")
     , fs = require("fs")
     , iterateObject = require("iterate-object")
@@ -69,6 +70,29 @@ class JsonEditor {
             return findValue(this.data, path)
         }
         return this.toObject();
+    }
+
+    /**
+     * unset
+     * Remove a path from a JSON object.
+     *
+     * @name unset
+     * @function
+     * @param {String} path The object path.
+     * @returns {JsonEditor} The `JsonEditor` instance.
+     */
+    unset (path) {
+        if (typeof path === "object") {
+            iterateObject(path, (val, n) => {
+                unsetValue(this.data, n)
+            });
+        } else {
+            unsetValue(this.data, path);
+        }
+        if (this.options.autosave) {
+            this.save();
+        }
+        return this;
     }
 
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 const findValue = require("find-value")
     , setValue = require("set-value")
-    , unsetValue = require("unset-value")
     , rJson = require("r-json")
     , fs = require("fs")
     , iterateObject = require("iterate-object")
@@ -82,17 +81,7 @@ class JsonEditor {
      * @returns {JsonEditor} The `JsonEditor` instance.
      */
     unset (path) {
-        if (typeof path === "object") {
-            iterateObject(path, (val, n) => {
-                unsetValue(this.data, n)
-            });
-        } else {
-            unsetValue(this.data, path);
-        }
-        if (this.options.autosave) {
-            this.save();
-        }
-        return this;
+        return this.set(path, undefined);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ease"
   ],
   "license": "MIT",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -44,6 +44,7 @@
     "iterate-object": "^1.3.2",
     "r-json": "^1.2.5",
     "set-value": "^0.4.0",
+    "unset-value": "1.0.0",
     "w-json": "^1.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "iterate-object": "^1.3.2",
     "r-json": "^1.2.5",
     "set-value": "^0.4.0",
-    "unset-value": "1.0.0",
     "w-json": "^1.3.5"
   }
 }


### PR DESCRIPTION
Proposed fix for Issue #11 which allows you to `unset` values in a `JsonEditor` object as well. This is new functionality that is non-breaking, so based on SEMVER this would be a MINOR upgrade from `1.0.8` to `1.1.0`.