### PR TITLE
fix(Audit): Use set-value@^3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "find-value": "^1.0.3",
     "iterate-object": "^1.3.2",
     "r-json": "^1.2.5",
-    "set-value": "^0.4.0",
+    "set-value": "^3.0.1",
     "w-json": "^1.3.5"
   }
 }


### PR DESCRIPTION
### In this PR
- npm audit fix for vulnerability in set-value


#### Summary

  High            Prototype Pollution                                           
                                                                                
  Package         set-value                                                     
                                                                                
  Patched in      >=2.0.1 <3.0.0 || >=3.0.1                                     
                                                                                
  Dependency of   edit-json-file [dev]                                          
                                                                                
  Path            edit-json-file > set-value                                    
                                                                                
  More info       https://nodesecurity.io/advisories/1012     