### PR TITLE
Add support for dot notation get/set with flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ There are few ways to get help:
  - `stringify_fn` (Function): A function used by `JSON.stringify`.
  - `stringify_eol` (Boolean): Wheter to add the new line at the end of the file or not (default: `false`)
  - `autosave` (Boolean): Save the file when setting some data in it.
+ - `ignoreDots` (Boolean): ignore any dots in keys/paths to not create nested structures.
 
 #### Return
 - **JsonEditor** The `JsonEditor` instance.

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ class JsonEditor {
         options.stringify_width = options.stringify_width || 2
         options.stringify_fn = options.stringify_fn || null
         options.stringify_eol = options.stringify_eol || false
+	options.ignoreDots = options.ignoreDots || false;
         this.path = path
         this.data = this.read()
     }
@@ -43,12 +44,12 @@ class JsonEditor {
      * @param {Anything} value The value.
      * @returns {JsonEditor} The `JsonEditor` instance.
      */
-    set (path, value, { ignoreDots = false } = {}) {
+    set (path, value) {
         if (typeof path === "object") {
             iterateObject(path, (val, n) => {
                 setValue(this.data, n, val)
             })
-        } else if(ignoreDots) {
+        } else if(this.options.ignoreDots) {
             this.data[path] = value;
 	} else {
             setValue(this.data, path, value)
@@ -68,9 +69,9 @@ class JsonEditor {
      * @param {String} path
      * @returns {Value} The object path value.
      */
-    get (path, { ignoreDots = false } = {}) {
+    get (path) {
         if (path) {
-	    if(ignoreDots) {
+	    if(this.options.ignoreDots) {
 		return this.data[path];
 	    }
             return findValue(this.data, path)

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,12 +43,14 @@ class JsonEditor {
      * @param {Anything} value The value.
      * @returns {JsonEditor} The `JsonEditor` instance.
      */
-    set (path, value) {
+    set (path, value, { ignoreDots = false } = {}) {
         if (typeof path === "object") {
             iterateObject(path, (val, n) => {
                 setValue(this.data, n, val)
             })
-        } else {
+        } else if(ignoreDots) {
+            this.data[path] = value;
+	} else {
             setValue(this.data, path, value)
         }
         if (this.options.autosave) {
@@ -66,8 +68,11 @@ class JsonEditor {
      * @param {String} path
      * @returns {Value} The object path value.
      */
-    get (path) {
+    get (path, { ignoreDots = false } = {}) {
         if (path) {
+	    if(ignoreDots) {
+		return this.data[path];
+	    }
             return findValue(this.data, path)
         }
         return this.toObject()


### PR DESCRIPTION
Settings support key dot notation escape, e.g. `editor.set('city\\.name', 'mycity');`
But get doesn't work with the same `editor.get('city\\.name'); // undefined`

The proposed solution is to simply add a flag for readability:
```js
editor.set('city.name', { ignoreDots: true });
editor.get('city.name', { ignoreDots: true }); // mycity
```

Added the `ignoreDots` option to `set` to avoid hard to read code (non matching keys):
```js
// would not work
const key = 'city\\.name';
editor.set(key, 'mycity');
editor.get(key, { ignoreDots: true }) // undefined
```