### PR TITLE
feat: add toString()

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -115,6 +115,12 @@ Save the file back to disk.
 #### Return
 - **Object** The data object.
 
+### `toString()`
+Get the current data as string.
+
+#### Return
+- **String** The stringified data.
+
 ### `editJsonFile(path, options)`
 Edit a json file.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -202,7 +202,7 @@ class JsonEditor {
             this.data
           , this.options.stringify_fn
           , this.options.stringify_width
-        ) + this.options.stringify_eol ? os.EOL : ''
+        ) + (this.options.stringify_eol ? os.EOL : '')
     }
 
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,6 +190,22 @@ class JsonEditor {
     }
 
     /**
+     * toString
+     * Get the current data as string.
+     *
+     * @name toString
+     * @function
+     * @returns {string} The data as string.
+     */
+    toString () {
+        return JSON.stringify(
+            this.data
+          , this.options.stringify_fn
+          , this.options.stringify_width
+        ) + this.options.stringify_eol ? os.EOL : ''
+    }
+
+    /**
      * save
      * Save the file back to disk.
      *
@@ -199,13 +215,7 @@ class JsonEditor {
      * @returns {JsonEditor} The `JsonEditor` instance.
      */
     save (cb) {
-        const data = JSON.stringify(
-	    this.data
-	  , this.options.stringify_fn
-	  , this.options.stringify_width
-	  , this.options.stringify_eol
-	)
-        this.write(this.options.stringify_eol ? data + os.EOL : data, cb);
+        this.write(this.toString(), cb);
         return this
     }
 


### PR DESCRIPTION
I did this to integrate more easily with https://github.com/keithamus/sort-package-json.

This way I can do all the changes to my package.json, .toString(), sortPackageJson(string), and then .write().

While `sortPackageJson` accepts an object, I preferred doing this way to keep the edit-json-file inner JSON.stringify() options.